### PR TITLE
NEW FEATURE: Store Discord account details in Discourse to facilitate cross system identification

### DIFF
--- a/db/migrate/20190816114100_move_discord_to_managed_authenticator.rb
+++ b/db/migrate/20190816114100_move_discord_to_managed_authenticator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class MoveDiscordToManagedAuthenticator < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      INSERT INTO user_associated_accounts (
+        provider_name,
+        provider_uid,
+        user_id,
+        info,
+        created_at,
+        updated_at
+      ) SELECT
+        'discord',
+        oui.uid,
+        oui.user_id,
+        json_build_object('email', oui.email, 'name', oui.name),
+        oui.created_at,
+        oui.updated_at
+      FROM oauth2_user_infos oui
+      WHERE provider = 'discord'
+      ON CONFLICT DO NOTHING
+    SQL
+  end
+end

--- a/db/post_migrate/20190816114200_remove_old_discord_records.rb
+++ b/db/post_migrate/20190816114200_remove_old_discord_records.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveOldDiscordRecords < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      DELETE FROM oauth2_user_infos
+      WHERE provider = 'discord'
+    SQL
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -57,11 +57,6 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
       end
     end
 
-    if trustedGuild && !User.find_by_email(auth_token.info.email)
-      systemUser = User.find_by(id: -1)
-      Invite.generate_invite_link(auth_token.info.email, systemUser)
-    end
-
     result = super
 
     if trustedGuild
@@ -74,13 +69,14 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
   end
 
   def after_create_account(user, auth)
-     super
+    super
 
-     data = auth[:extra_data]
-     if !user.approved && data[:auto_approve]
-       systemUser = User.find_by(id: -1)
-       ReviewableUser.set_approved_fields!(user, systemUser)
-     end
+    data = auth[:extra_data]
+    if !user.approved && data[:auto_approve]
+      user.approved = true
+      user.approved_by = Discourse.system_user
+      user.save!
+    end
   end
 end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,13 +70,14 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
 
   def after_create_account(user, auth)
     super
-    
+
     data = auth[:extra_data]
     if !user.approved && data[:auto_approve]
       user.approved = true
-      user.approved_by = Discourse.system_user
-      if reviewable_user = ReviewableUser.find_by(target: user)
-          reviewable_user.set_approved_fields!(user, Discourse.system_user)
+      user.approved_by_id = Discourse.system_user.id
+      user.save!
+      if reviewable = ::ReviewableUser.pending.find_by(target: user)
+        reviewable.perform(:approve, Discourse.system_user)
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -30,16 +30,16 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
   end
 
   def register_middleware(omniauth)
-  omniauth.provider :discord,
-         setup: lambda { |env|
-           strategy = env["omniauth.strategy"]
-            strategy.options[:client_id] = SiteSetting.discord_client_id
-            strategy.options[:client_secret] = SiteSetting.discord_secret
-            strategy.options[:info_fields] = 'email,username'
-            strategy.options[:image_size] = { width: AVATAR_SIZE, height: AVATAR_SIZE }
-            strategy.options[:secure_image_url] = true
-         },
-         scope: 'identify email guilds'
+    omniauth.provider :discord,
+           setup: lambda { |env|
+             strategy = env["omniauth.strategy"]
+              strategy.options[:client_id] = SiteSetting.discord_client_id
+              strategy.options[:client_secret] = SiteSetting.discord_secret
+              strategy.options[:info_fields] = 'email,username'
+              strategy.options[:image_size] = { width: AVATAR_SIZE, height: AVATAR_SIZE }
+              strategy.options[:secure_image_url] = true
+           },
+           scope: 'identify email guilds'
   end
 
   def after_authenticate(auth_token)

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,7 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
            strategy = env["omniauth.strategy"]
             strategy.options[:client_id] = SiteSetting.discord_client_id
             strategy.options[:client_secret] = SiteSetting.discord_secret
-            strategy.options[:info_fields] = 'avatar,discriminator,email,flag,id,locale,mfa_enabled,username,verified'
+            strategy.options[:info_fields] = 'email,username'
             strategy.options[:image_size] = { width: AVATAR_SIZE, height: AVATAR_SIZE }
             strategy.options[:secure_image_url] = true
          },
@@ -62,12 +62,7 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
 
     result = super
     data = auth_token[:info]
-    result.extra_data[:avatar_url] = data[:image]
-
-
-    if (avatar_url = data[:image]).present?
-      retrieve_avatar(result.user, avatar_url)
-    end
+    
     if trustedGuild
       result.extra_data[:auto_approve] = true
     else

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,12 +70,14 @@ class DiscordAuthenticator < ::Auth::ManagedAuthenticator
 
   def after_create_account(user, auth)
     super
-
+    
     data = auth[:extra_data]
     if !user.approved && data[:auto_approve]
       user.approved = true
       user.approved_by = Discourse.system_user
-      user.save!
+      if reviewable_user = ReviewableUser.find_by(target: user)
+          reviewable_user.set_approved_fields!(user, Discourse.system_user)
+      end
     end
   end
 end


### PR DESCRIPTION
 - Stores Discord User ID, email, nickname and image location in Discourse (in user_associated_accounts table)
 - Simplified implementation significantly by upgrading inheritance to Auth::ManagedAuthenticator.
 - Added support for the new core Reviewable queue (membership of trusted Guild removes any Review automatically).
- Paves the way for automating Discord account management from Discourse.

